### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -1,5 +1,8 @@
 name: Sync Data After Merge
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/renaissanceabc/the-montessorians/security/code-scanning/10](https://github.com/renaissanceabc/the-montessorians/security/code-scanning/10)

To fix the issue, we will add a `permissions` block at the root level of the workflow to explicitly define the minimal permissions required. Since the workflow only reads pull request metadata and does not perform any write operations, we will set `contents: read` as the minimal permission. This ensures that the workflow has only the permissions it needs to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
