### PR TITLE
docs: clarify open source licensing for public repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,5 +72,6 @@ links:
 
 ## 📄 License
 
-By contributing, you agree that your additions will be released under
-[CC0](https://github.com/renaissanceabc/the-montessorians?tab=CC0-1.0-1-ov-file#readme).
+By contributing, you agree that dataset additions (`data/` and `images/`) are released under
+[CC0](./LICENSE.md), and that code contributions (`apps/` and `packages/`) are released under the
+[MIT license](./LICENSE-CODE.md).

--- a/LICENSE-CODE.md
+++ b/LICENSE-CODE.md
@@ -1,0 +1,28 @@
+# MIT License
+
+Copyright (c) 2026 Renaissance Education
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+This MIT license covers the **application code** in this repository
+(`apps/` and `packages/`). The **dataset** (`data/` and `images/`) is dedicated
+to the public domain under [CC0 1.0 Universal](./LICENSE.md). See the
+[README](./README.md#license) for details.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 [The Montessorians](https://themontessorians.xyz) is the world's largest open source dataset of Montessori alumni who've
 gone on to do great things.
 
-The Montessorians is fully community-driven and open for contributions under a Creative Commons CC0 license.
+This is the public, open source home of both the **dataset** and the **website** that renders it. The dataset is
+fully community-driven and dedicated to the public domain under [CC0](./LICENSE.md), and the website's source code is
+open source under the [MIT license](./LICENSE-CODE.md). Contributions to both are welcome.
 
 Created and maintained by [Renaissance](https://renaissance.education), an education startup studio.
 
@@ -13,9 +15,9 @@ Created and maintained by [Renaissance](https://renaissance.education), an educa
 
 This repository holds both the **dataset** and the **website** that renders it ([themontessorians.xyz](https://themontessorians.xyz)).
 
-- `data/` — structured YAML files, one per person (the dataset; **CC0**)
-- `images/` — associated profile images (the dataset; **CC0**)
-- `apps/` and `packages/` — the Next.js website and its supporting packages (the application code; see [`LICENSE.md`](./LICENSE.md))
+- `data/` — structured YAML files, one per person (the dataset; **CC0**, see [`LICENSE.md`](./LICENSE.md))
+- `images/` — associated profile images (the dataset; **CC0**, see [`LICENSE.md`](./LICENSE.md))
+- `apps/` and `packages/` — the Next.js website and its supporting packages (the application code; **MIT**, see [`LICENSE-CODE.md`](./LICENSE-CODE.md))
 
 ```
 /data/                 # CC0 dataset
@@ -99,10 +101,20 @@ Know someone who should be featured? Submit a pull request or open an issue.
 
 ---
 
-### License
+### Contribution License
 
-By contributing, you agree that your additions will be released under
-[CC0](https://github.com/renaissanceabc/the-montessorians?tab=CC0-1.0-1-ov-file#readme).
+By contributing, you agree that dataset additions (`data/` and `images/`) are released under
+[CC0](./LICENSE.md), and that code contributions (`apps/` and `packages/`) are released under the
+[MIT license](./LICENSE-CODE.md).
+
+---
+
+## License
+
+This repository is open source and dual-licensed:
+
+- **Dataset** (`data/`, `images/`) — [CC0 1.0 Universal](./LICENSE.md) (public domain dedication)
+- **Application code** (`apps/`, `packages/`) — [MIT](./LICENSE-CODE.md)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "node": ">=22"
   },
   "description": "The largest open source dataset of Montessori alumni, and the website that renders it",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/renaissanceabc/the-montessorians.git"


### PR DESCRIPTION
Now that the web app is open sourced and the repo is public, clarifies licensing across the repo.

## Changes
- **Add `LICENSE-CODE.md`** — MIT license for the application code (`apps/`, `packages/`). Previously the README pointed code at `LICENSE.md`, but that file is CC0 (written for the dataset), so the code had no real license.
- **README** — intro now frames the repo as the public, open source home of both dataset and website; structure list labels each path's license; added a dedicated top-level License section documenting the dual license (dataset CC0 / code MIT).
- **CONTRIBUTING.md** — contribution license note updated to the dual-license framing.
- **package.json** — added `"license": "MIT"`.

## Note
GitHub's sidebar will detect `LICENSE.md` (CC0) as the repo license by filename convention; MIT lives in `LICENSE-CODE.md` and is documented in the README. Swap filenames if we'd rather surface MIT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)